### PR TITLE
chore(AV-1489): prevent concurrent CI/CD jobs on same branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,9 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    concurrency:
+      group: ${{ github.ref }}
+      cancel-in-progress: true
     permissions:
       id-token: write
       contents: read
@@ -59,6 +62,8 @@ jobs:
     name: release
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    concurrency:
+      group: ${{ github.ref }}
     needs:
       - build
     outputs:
@@ -86,6 +91,8 @@ jobs:
     name: tag
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    concurrency:
+      group: ${{ github.ref }}
     needs:
       - release
     if: always() && needs.release.outputs.new_release_published == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ jobs:
     name: test-build
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    concurrency:
+      group: ${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -45,6 +48,8 @@ jobs:
     name: test-release
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    concurrency:
+      group: ${{ github.ref }}
     steps:
       - name: checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Prevent concurrent jobs. This makes sure commits and pushes in rapid succession do not create unnecessary jobs or unnecessary individual releases.