### PR TITLE
AV-1583:  Guide Page Arrowbox

### DIFF
--- a/modules/avoindata-theme/js/cycle_guide_menu_items.js
+++ b/modules/avoindata-theme/js/cycle_guide_menu_items.js
@@ -149,14 +149,28 @@ class MenuUtils {
     }
 }
 
-class CycleMenuItemsView {
+class GuidePageView {
     constructor(menuUtils) {
         this.currentPath = window.location.pathname;
         this.nextBtn = document.getElementById('next-page-btn');
         this.prevBtn = document.getElementById('previous-page-btn');
         this.paths = menuUtils.getMenuPaths();
+        this.arrowBoxTitleSelector = document.getElementById('arrow-box-title');
 
         this.setAnchorLinks();
+        this.setArrowBoxTitle();
+    }
+
+    setArrowBoxTitle() {
+        if (this.paths.length <= 0) {
+            return;
+        }
+
+        // First item in the list should be the header which will be displayed in the Arrowbox.
+        let headerPathName = this.paths[0].itemName;
+        if (headerPathName) {
+            this.arrowBoxTitleSelector.innerText = headerPathName;
+        }
     }
 
     setAnchorLinks() {
@@ -202,5 +216,5 @@ class CycleMenuItemsView {
 }
 
 document.addEventListener('DOMContentLoaded', (event) => {
-    new CycleMenuItemsView(new MenuUtils());
+    new GuidePageView(new MenuUtils());
 });

--- a/modules/avoindata-theme/templates/node/node--avoindata_guide_page.html.twig
+++ b/modules/avoindata-theme/templates/node/node--avoindata_guide_page.html.twig
@@ -7,6 +7,9 @@
  */
 #}
 {{ attach_library('avoindata/cycle-guide-menu-items') }}
+<div class="arrow-box">
+    <h1 id="arrow-box-title">{% trans %}Guides{% endtrans %}</h1>
+</div>
 <div id="guide-page" class="container-fluid">
     <div class="avoindata-guide-container avoindata-card-container">
         {% set has_menu = (drupal_region('guide_menu')|render|trim) is not empty %}


### PR DESCRIPTION
Implement an arrowbox for the guide pages which holds the header from the guide page menu. The the arrowbox grabs the text from the header dynamically but falls back to "Oppaat" if something goes wrong.

Refs AV-1583 