### PR TITLE
AV-1664: hide guide page arrowbox

### DIFF
--- a/modules/avoindata-theme/js/cycle_guide_menu_items.js
+++ b/modules/avoindata-theme/js/cycle_guide_menu_items.js
@@ -156,6 +156,7 @@ class GuidePageView {
         this.prevBtn = document.getElementById('previous-page-btn');
         this.paths = menuUtils.getMenuPaths();
         this.arrowBoxTitleSelector = document.getElementById('arrow-box-title');
+        this.arrowBoxSelector = document.getElementById('js-arrow-box');
 
         this.setAnchorLinks();
         this.setArrowBoxTitle();
@@ -166,6 +167,8 @@ class GuidePageView {
             return;
         }
 
+        this.arrowBoxSelector.style.display = 'block';
+
         // First item in the list should be the header which will be displayed in the Arrowbox.
         let headerPathName = this.paths[0].itemName;
         if (headerPathName) {
@@ -174,6 +177,10 @@ class GuidePageView {
     }
 
     setAnchorLinks() {
+        if (this.paths.length <= 0) {
+            return;
+        }
+
         const currentPageIndex = this.getIndexOfCurrentPage();
 
         this.setNextAnchorLink(currentPageIndex);

--- a/modules/avoindata-theme/templates/node/node--avoindata_guide_page.html.twig
+++ b/modules/avoindata-theme/templates/node/node--avoindata_guide_page.html.twig
@@ -7,8 +7,8 @@
  */
 #}
 {{ attach_library('avoindata/cycle-guide-menu-items') }}
-<div class="arrow-box">
-    <h1 id="arrow-box-title">{% trans %}Guides{% endtrans %}</h1>
+<div class="arrow-box" id="js-arrow-box">
+    <h1 id="arrow-box-title"></h1>
 </div>
 <div id="guide-page" class="container-fluid">
     <div class="avoindata-guide-container avoindata-card-container">


### PR DESCRIPTION
Hide the guide page arrowbox if there is no menu on the guide page. Display the arrowbox only if a menu is present.