### PR TITLE
AV-1666:  guide page next page link fix

### DIFF
--- a/modules/avoindata-theme/js/cycle_guide_menu_items.js
+++ b/modules/avoindata-theme/js/cycle_guide_menu_items.js
@@ -190,8 +190,7 @@ class GuidePageView {
     setNextAnchorLink(currentPageIndex) {
         const currentElement = this.paths[currentPageIndex];
         if (currentElement.next === undefined) {
-            this.nextBtn.innerHTML = '';
-            this.nextBtn.href = '';
+            this.nextBtn.style.display = 'none';
             return;
         }
 
@@ -205,8 +204,7 @@ class GuidePageView {
     setPrevAnchorLink(currentPageIndex) {
         const currentElement = this.paths[currentPageIndex];
         if (currentElement.prev === undefined) {
-            this.prevBtn.innerHTML = '';
-            this.prevBtn.href = '';
+            this.prevBtn.style.display = 'none';
             return;
         }
 


### PR DESCRIPTION
Remove the previous/next links when reach first or last page in the guide page menu instead of only removing the text in the links.