### PR TITLE
AV-1650:  Fix menu not available

### DIFF
--- a/modules/avoindata-theme/js/cycle_guide_menu_items.js
+++ b/modules/avoindata-theme/js/cycle_guide_menu_items.js
@@ -167,8 +167,6 @@ class GuidePageView {
             return;
         }
 
-        this.arrowBoxSelector.style.display = 'block';
-
         // First item in the list should be the header which will be displayed in the Arrowbox.
         let headerPathName = this.paths[0].itemName;
         if (headerPathName) {

--- a/modules/avoindata-theme/templates/node/node--avoindata_guide_page.html.twig
+++ b/modules/avoindata-theme/templates/node/node--avoindata_guide_page.html.twig
@@ -7,12 +7,14 @@
  */
 #}
 {{ attach_library('avoindata/cycle-guide-menu-items') }}
+{% set has_menu = drupal_region('guide_menu')|render|striptags|trim %}
+
 <div class="arrow-box" id="js-arrow-box">
     <h1 id="arrow-box-title"></h1>
 </div>
+
 <div id="guide-page" class="container-fluid">
     <div class="avoindata-guide-container avoindata-card-container">
-        {% set has_menu = (drupal_region('guide_menu')|render|trim) is not empty %}
         <div class="row guide-header-container">
             <div class="col-xs-12 {{ has_menu ? 'col-md-8 col-md-push-4 col--guide-right' : ''}}">
                 <h1 id="guide-header">

--- a/modules/avoindata-theme/templates/node/node--avoindata_guide_page.html.twig
+++ b/modules/avoindata-theme/templates/node/node--avoindata_guide_page.html.twig
@@ -9,9 +9,12 @@
 {{ attach_library('avoindata/cycle-guide-menu-items') }}
 {% set has_menu = drupal_region('guide_menu')|render|striptags|trim %}
 
-<div class="arrow-box" id="js-arrow-box">
-    <h1 id="arrow-box-title"></h1>
-</div>
+
+{% if has_menu %}
+    <div class="arrow-box" id="js-arrow-box">
+        <h1 id="arrow-box-title"></h1>
+    </div>
+{% endif %}
 
 <div id="guide-page" class="container-fluid">
     <div class="avoindata-guide-container avoindata-card-container">


### PR DESCRIPTION
Checking whether the guide menu is present in the guide pages did not work as intended in the previous implementation. This was fixed by adding an additional filter to the "has_menu" check in the template logic of the guide pages. This check replaces the javascript logic for showing/hiding the the arrowbox in the guide pages as well.